### PR TITLE
【OJT後半課題①】単体テスト　作成

### DIFF
--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
@@ -50,7 +50,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
 	// FaceAPI‚©‚ç400,429ˆÈŠO‚ÌƒGƒ‰[‚ª•Ô‹p‚³‚ê‚½ê‡‚Ìˆ—
 	@ExceptionHandler(FaceApiException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	public FaceApiErrorResponse handleFaceApiException(HttpServletRequest req, FaceApiException ex)
 			throws JsonMappingException, JsonProcessingException {
 		return ResponseFactory.createFaceApiErrorResponse(ex);

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
@@ -61,7 +61,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 	@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
 	public FaceApiErrorResponse handleFaceApiException(HttpServletRequest req, FaceApiServerException ex)
 			throws JsonMappingException, JsonProcessingException {
-		return ResponseFactory.createFaceApiErrorResponse(ex);
+		return ResponseFactory.createFaceApiServerError(ex);
 	}
 
 	// メディアタイプが不正の場合の例外処理

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/ErrorHandler.java
@@ -4,7 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.ValidationException;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.face.model.ErrorMassage;
+import com.face.model.ErrorMessage;
 import com.face.model.ErrorResponse;
 import com.face.model.FaceApiErrorResponse;
 import com.face.response.FaceApiException;
@@ -69,7 +68,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 	@Override
 	protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
 			org.springframework.http.HttpHeaders headers, HttpStatus status, WebRequest request) {
-		return new ResponseEntity<>(new ErrorResponse(ErrorMassage.MEDIA_TYPE_ERROR), HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+		return new ResponseEntity<>(new ErrorResponse(ErrorMessage.MEDIA_TYPE_ERROR), HttpStatus.UNSUPPORTED_MEDIA_TYPE);
 	}
 
 	// ÇªÇÃëºÇÃÉGÉâÅ[ÇÃèÍçá

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
@@ -22,20 +22,21 @@ import com.face.model.ErrorMessage;
 import com.face.model.ImageInfo;
 import com.face.model.ResultData;
 import com.face.response.FaceApiException;
+import com.face.response.FaceApiInvalidRequestException;
 import com.face.response.FaceApiServerException;
 import com.face.response.NotDetectedException;
 
 @RestController
 @RequestMapping("/face")
 public class FaceEmotionController {
-	
+
 	@Bean
 	public RestTemplate restTemplate() {
-	    return new RestTemplate();
+		return new RestTemplate();
 	}
 
 	@Autowired
-    private RestTemplate restTemplate;
+	private RestTemplate restTemplate;
 
 	@Value("${SUBSCRIPTION_KEY}")
 	private String subcscriptiponKey;
@@ -59,7 +60,7 @@ public class FaceEmotionController {
 		// 画像URL と 分析項目を指定
 		String queryUrl = endPoint + "?detectionModel=detection_01&returnFaceAttributes=emotion&returnFaceId=true";
 		String imageQueryStr = "?sv=2019-07-07&sr=c&si=myPolicyPS&sig=FkKJ4nXCiqzDYjbSaDfqli%2FnErPRTKrD%2BUQfH0MT3ac%3D"; // サーバー上に置かれている画像にアクセスするために必要なクエリ文字列。処理には関係なし。
-		
+
 		Map<String, String> map = new HashMap<>();
 		map.put("url", url.getUrl() + imageQueryStr);
 		HttpEntity<Object> request = new HttpEntity<Object>(map, headers);
@@ -71,11 +72,11 @@ public class FaceEmotionController {
 		} catch (HttpClientErrorException e) {
 			// FaceAPIがエラーの場合
 			if (e.getRawStatusCode() == 400 || e.getRawStatusCode() == 429) {
-				throw new FaceApiException(e.getResponseBodyAsString());
+				throw new FaceApiInvalidRequestException(e.getResponseBodyAsString());
 			} else {
-				throw new FaceApiServerException(e.getResponseBodyAsString());
+				throw new FaceApiException(e.getResponseBodyAsString());
 			}
-		}catch (HttpServerErrorException e) {
+		} catch (HttpServerErrorException e) {
 			// FaceAPIがエラーの場合
 			if (e.getRawStatusCode() == 503) {
 				throw new FaceApiServerException(e.getResponseBodyAsString());

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
@@ -9,17 +9,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import com.face.model.ErrorMassage;
+import com.face.model.ErrorMessage;
 import com.face.model.ImageInfo;
 import com.face.model.ResultData;
 import com.face.response.FaceApiException;
@@ -36,7 +34,6 @@ public class FaceEmotionController {
 	    return new RestTemplate();
 	}
 
-//	private final RestTemplate restTemplate = new RestTemplate();
 	@Autowired
     private RestTemplate restTemplate;
 
@@ -51,7 +48,7 @@ public class FaceEmotionController {
 
 		// パラメータが不正な場合
 		if (url.getUrl() == null || url.getUrl().isEmpty()) {
-			throw new ValidationException(ErrorMassage.REQUEST_BODY_ERROR);
+			throw new ValidationException(ErrorMessage.REQUEST_BODY_ERROR);
 		}
 
 		// ヘッダ設定
@@ -76,12 +73,12 @@ public class FaceEmotionController {
 			if (e.getRawStatusCode() == 400 || e.getRawStatusCode() == 429) {
 				throw new FaceApiException(e.getResponseBodyAsString());
 			} else if (e.getRawStatusCode() == 503) {
-				throw new FaceApiServerException(ErrorMassage.FACE_API_SERVER_UNABLABLE_ERROR);
+				throw new FaceApiServerException(ErrorMessage.FACE_API_SERVER_UNABLABLE_ERROR);
 			} else {
-				throw new FaceApiInvalidRequestException(ErrorMassage.FACE_API_RESPONSE_ERROR);
+				throw new FaceApiInvalidRequestException(ErrorMessage.FACE_API_RESPONSE_ERROR);
 			}
 		} catch (Exception e) {
-			throw new Exception(ErrorMassage.UNEXPECTED_ERROR);
+			throw new Exception(ErrorMessage.UNEXPECTED_ERROR);
 		}
 
 		// 顔が検出されなかった場合

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/controller/FaceEmotionController.java
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import com.face.model.ErrorMessage;
 import com.face.model.ImageInfo;
 import com.face.model.ResultData;
 import com.face.response.FaceApiException;
-import com.face.response.FaceApiInvalidRequestException;
 import com.face.response.FaceApiServerException;
 import com.face.response.NotDetectedException;
 
@@ -72,10 +72,15 @@ public class FaceEmotionController {
 			// FaceAPIがエラーの場合
 			if (e.getRawStatusCode() == 400 || e.getRawStatusCode() == 429) {
 				throw new FaceApiException(e.getResponseBodyAsString());
-			} else if (e.getRawStatusCode() == 503) {
-				throw new FaceApiServerException(ErrorMessage.FACE_API_SERVER_UNABLABLE_ERROR);
 			} else {
-				throw new FaceApiInvalidRequestException(ErrorMessage.FACE_API_RESPONSE_ERROR);
+				throw new FaceApiServerException(e.getResponseBodyAsString());
+			}
+		}catch (HttpServerErrorException e) {
+			// FaceAPIがエラーの場合
+			if (e.getRawStatusCode() == 503) {
+				throw new FaceApiServerException(e.getResponseBodyAsString());
+			} else {
+				throw new Exception(ErrorMessage.UNEXPECTED_ERROR);
 			}
 		} catch (Exception e) {
 			throw new Exception(ErrorMessage.UNEXPECTED_ERROR);

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/ErrorMessage.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/ErrorMessage.java
@@ -1,6 +1,6 @@
 package com.face.model;
 
-public class ErrorMassage {
+public class ErrorMessage {
 
 	public final static String REQUEST_BODY_ERROR = "request body is invalid.";
 	public final static String MEDIA_TYPE_ERROR = "media type is invalid.";

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/FaceApiErrorResponse.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/FaceApiErrorResponse.java
@@ -16,7 +16,7 @@ public class FaceApiErrorResponse{
 		public FaceApiErrorResponseDetail getDetails() {
 			return details;
 		}
-
+		
 		@JsonProperty("error")
 		public void setDetails(FaceApiErrorResponseDetail error) {
 			this.details = error;

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/ImageInfo.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/model/ImageInfo.java
@@ -2,7 +2,7 @@ package com.face.model;
 
 public class ImageInfo {
 	private String url;
-	
+
 	public void setUrl(String url) {
 		this.url = url;
 	}

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/FaceApiErrorResponseDetail.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/FaceApiErrorResponseDetail.java
@@ -12,6 +12,14 @@ public class FaceApiErrorResponseDetail {
 		return code;
 	}
 
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
 	public String getMessage() {
 		return message;
 	}

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
@@ -1,11 +1,14 @@
 package com.face.response;
 
+import org.springframework.stereotype.Component;
+
 import com.face.model.ErrorResponse;
 import com.face.model.FaceApiErrorResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Component
 public class ResponseFactory {	
 	
 	public static ErrorResponse createErrorResponse(Exception ex) {

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
@@ -21,7 +21,17 @@ public class ResponseFactory {
        
 		ObjectMapper mapper = new ObjectMapper();
 		FaceApiErrorResponse err = mapper.readValue(ex.getMessage(), FaceApiErrorResponse.class);
+		
 		err.setMessage(ErrorMessage.FACE_API_RESPONSE_ERROR);
+		return err;
+	}
+	
+	public static FaceApiErrorResponse createFaceApiServerError(Exception ex) throws JsonMappingException, JsonProcessingException {
+	       
+		ObjectMapper mapper = new ObjectMapper();
+		FaceApiErrorResponse err = mapper.readValue(ex.getMessage(), FaceApiErrorResponse.class);
+		
+		err.setMessage(ErrorMessage.FACE_API_SERVER_UNABLABLE_ERROR);
 		return err;
 	}
 }

--- a/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
+++ b/server/FaceEmotionAnalyzerAPI/src/main/java/com/face/response/ResponseFactory.java
@@ -2,6 +2,7 @@ package com.face.response;
 
 import org.springframework.stereotype.Component;
 
+import com.face.model.ErrorMessage;
 import com.face.model.ErrorResponse;
 import com.face.model.FaceApiErrorResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,7 +21,7 @@ public class ResponseFactory {
        
 		ObjectMapper mapper = new ObjectMapper();
 		FaceApiErrorResponse err = mapper.readValue(ex.getMessage(), FaceApiErrorResponse.class);
-		err.setMessage("Face API response is error.");
+		err.setMessage(ErrorMessage.FACE_API_RESPONSE_ERROR);
 		return err;
 	}
 }

--- a/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/controller/FaceEmotionControllerTest.java
+++ b/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/controller/FaceEmotionControllerTest.java
@@ -1,0 +1,166 @@
+package com.face.controller;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.RestTemplate;
+
+//import com.face.model.ErrorResponse;
+//import com.face.model.ErrorMassage;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class FaceEmotionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	RestTemplate restTemplate;
+
+//	@Mock
+//	RestTemplate restTemplate;
+//	@InjectMocks
+
+	@Autowired
+	FaceEmotionController target;
+
+	@Value("${SUBSCRIPTION_KEY}")
+	private String subcscriptiponKey;
+
+	@Value("${END_POINT_FACE_API}")
+	private String endPoint;
+
+	private String url = endPoint + "?detectionModel=detection_01&returnFaceAttributes=emotion&returnFaceId=true";
+	private String ImageUrl = "https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg"
+			+ "?sv=2019-07-07&sr=c&si=myPolicyPS&sig=FkKJ4nXCiqzDYjbSaDfqli%2FnErPRTKrD%2BUQfH0MT3ac%3D";
+
+//	RestTemplate restTemplate = new RestTemplate();
+
+	@Before
+	public void setup() {
+		mockMvc = MockMvcBuilders.standaloneSetup(target).build();
+	}
+
+	// 成功時のテスト
+	@Test
+	void testAnalyzSuccess() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
+				.andExpect(status().isOk());
+	}
+
+	// 顔が検出されない場合のテスト
+	@Test
+	void testAnalyzeErrorNotDetected() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/02.jpg\"}"))
+				.andExpect(status().isBadRequest());
+	}
+
+	// POSTパラメータが不正の場合のテスト
+	@Test
+	void testAnalyzeErrorinvalidBody() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"uri\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/02.jpg\"}"))
+				.andExpect(status().isBadRequest());
+	}
+
+	// POSTパラメータが未入力の場合のテスト
+	@Test
+	void testAnalyzeNoEnterdBody() throws Exception {
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON).content(""))
+				.andExpect(status().isBadRequest());
+	}
+
+	// メディアタイプが不正の場合のテスト
+	@Test
+	void testAnalyzeErrorInvalidMediaType() throws Exception {
+//		ErrorResponse errorResponse = new ErrorResponse(ErrorMassage.REQUEST_BODY_ERROR);
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_PDF))
+				.andExpect(status().isUnsupportedMediaType());
+	}
+
+	// FaceAPIからHTTPステータス400が返却される場合
+	@Test
+	void testAnalyzeErrorReturn400() throws Exception {
+
+		// 返却されるレスポンス
+		String jsonResponseBody = "{ \"error\": { \"code\": \"request is invalid\", \"message\": \"パラメータが不正です。\"} }";
+		// モック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST))
+				.andRespond(withStatus(HttpStatus.BAD_REQUEST).body(jsonResponseBody));
+		// 実行
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
+				.andExpect(status().isBadRequest());
+
+		mockServer.verify();
+	}
+
+	// FaceAPIからHTTPステータス429が返却される場合
+	@Test
+	void testAnalyzeReturn429() throws Exception {
+
+		// 返却されるレスポンス
+		String jsonResponseBody = "{ \"error\": { \"code\": \"request is invalid\", \"message\": \"パラメータが不正です。\"} }";
+
+		// ヘッダ設定
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.add("Ocp-Apim-Subscription-Key", subcscriptiponKey);
+		// モック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST))
+				.andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS).body(jsonResponseBody));
+		// 実行
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
+				.andExpect(status().isBadRequest());
+
+		mockServer.verify();
+	}
+
+	// FaceAPIとの通信でHTTPステータス503が返却される場合
+	@Test
+	void testAnalyzeReturn503() throws Exception {
+
+		// 返却されるレスポンス
+		String jsonResponseBody = "{ \"error\": { \"code\": \"request is invalid\", \"message\": \"パラメータが不正です。\"} }";
+		// モック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST))
+				.andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE).body(jsonResponseBody));
+		// 実行
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
+				.andExpect(status().isServiceUnavailable());
+
+		mockServer.verify();
+	}
+
+}

--- a/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/controller/FaceEmotionControllerTest.java
+++ b/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/controller/FaceEmotionControllerTest.java
@@ -2,6 +2,8 @@ package com.face.controller;
 
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.Before;
@@ -16,9 +18,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.client.RestTemplate;
+
+import com.face.model.Emotion;
+import com.face.model.FaceAttributes;
+import com.face.model.FaceRectangle;
+import com.face.model.ResultData;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -34,31 +41,65 @@ class FaceEmotionControllerTest {
 	@Autowired
 	FaceEmotionController target;
 
-	@Before
-	public void setup() {
-		mockMvc = MockMvcBuilders.standaloneSetup(target).build();
-	}
-
 	// 成功時のテスト
-	// レスポンス　HTTPステータス200を期待
+	// レスポンス HTTPステータス200を期待
 	@Test
 	void testAnalyzSuccess() throws Exception {
+
+		// 返却されるレスポンス
+		Emotion emotion = new Emotion();
+		emotion.setAnger(0);
+		emotion.setContempt(0);
+		emotion.setDisgust(0);
+		emotion.setFear(0);
+		emotion.setHappiness(0);
+		emotion.setNeutral(0);
+		emotion.setSadness(0);
+		emotion.setSurprise(0);
+		FaceAttributes faceAttributes = new FaceAttributes();
+		faceAttributes.setEmotion(emotion);
+		FaceRectangle faceRectangle = new FaceRectangle();
+		faceRectangle.setTop(1);
+		faceRectangle.setLeft(2);
+		faceRectangle.setWidth(100);
+		faceRectangle.setHeight(200);
+		ResultData resultData = new ResultData();
+		resultData.setFaceId("580a572a-c529-4333-b93f-8429ebda8b18");
+		resultData.setFaceRectangle(faceRectangle);
+		resultData.setFaceAttributes(faceAttributes);
+		ResultData[] resultDatas = {resultData}; 
+		String str = resultDatas.toString();
+		
+		String jsonResponseBody = "[{\"faceId\":\"580a572a-c529-4333-b93f-8429ebda8b18\",\"faceRectangle\":{\"top\":128,\"left\":529,\"width\":109,\"height\":109},\"faceAttributes\":{\"emotion\":{\"anger\":0.0,\"contempt\":0.0,\"disgust\":0.0,\"fear\":0.0,\"happiness\":1.0,\"neutral\":0.0,\"sadness\":0.0,\"surprise\":0.0}}}]";
+		// FaceAPI通信のモック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.OK).body(jsonResponseBody));
+
 		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
 				.andExpect(status().isOk());
+//				.andExpect(content().json(jsonResponseBody));
 	}
-	
+
 	// 画像から顔が検出されない場合のテスト
-	// レスポンス　HTTPステータス400を期待
+	// レスポンス HTTPステータス400を期待
 	@Test
 	void testAnalyzeErrorNotDetected() throws Exception {
+		// 返却されるレスポンス
+		String jsonResponseBody = "";
+		// FaceAPI通信のモック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST)).andRespond(withSuccess().body(jsonResponseBody));
+
 		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
-				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/02.jpg\"}"))
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
 				.andExpect(status().isBadRequest());
 	}
 
-	// POSTパラメータが不正の場合のテスト　キー　"url" →　"uri"
-	// レスポンス　HTTPステータス400を期待
+	// POSTパラメータが不正の場合のテスト キー "url" → "uri"
+	// レスポンス HTTPステータス400を期待
 	@Test
 	void testAnalyzeErrorinvalidBody() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
@@ -67,16 +108,15 @@ class FaceEmotionControllerTest {
 	}
 
 	// POSTパラメータが未入力の場合のテスト
-	// レスポンス　HTTPステータス400を期待
+	// レスポンス HTTPステータス400を期待
 	@Test
 	void testAnalyzeNoEnterdBody() throws Exception {
-		mockMvc.perform(
-				MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest());
 	}
 
 	// メディアタイプが不正の場合のテスト
-	// レスポンス　HTTPステータス415を期待
+	// レスポンス HTTPステータス415を期待
 	@Test
 	void testAnalyzeErrorInvalidMediaType() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_PDF))
@@ -84,7 +124,7 @@ class FaceEmotionControllerTest {
 	}
 
 	// FaceAPIからHTTPステータス400が返却される場合
-	// レスポンス　HTTPステータス400を期待
+	// レスポンス HTTPステータス400を期待
 	@Test
 	void testAnalyzeErrorReturn400() throws Exception {
 
@@ -96,15 +136,17 @@ class FaceEmotionControllerTest {
 		mockServer.expect(method(HttpMethod.POST))
 				.andRespond(withStatus(HttpStatus.BAD_REQUEST).body(jsonResponseBody));
 		// 実行
-		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
-				.andExpect(status().isBadRequest());
+				.andExpect(status().isBadRequest())
+				.andReturn();
 
+		String content = result.getResponse().getContentAsString();
 		mockServer.verify();
 	}
 
 	// FaceAPIからHTTPステータス429が返却される場合
-	// レスポンス　HTTPステータス400を期待
+	// レスポンス HTTPステータス400を期待
 	@Test
 	void testAnalyzeReturn429() throws Exception {
 
@@ -123,8 +165,27 @@ class FaceEmotionControllerTest {
 		mockServer.verify();
 	}
 
+	// FaceAPIからHTTPステータス403(400,429以外)が返却される場合
+	// レスポンス HTTPステータス500を期待
+	@Test
+	void testAnalyzeReturn403() throws Exception {
+
+		// 返却されるレスポンス
+		String jsonResponseBody = "{ \"error\": { \"code\": \"BadArgument\", \"message\": \"Request body is invalid.\"} }";
+		// FaceAPI通信のモック
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true)
+				.bufferContent().build();
+		mockServer.expect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.FORBIDDEN).body(jsonResponseBody));
+		// 実行
+		mockMvc.perform(MockMvcRequestBuilders.post("/face/emotion").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"url\":\"https://nishikawa.blob.core.windows.net/images/sugimoto/2020/11/01/01.jpg\"}"))
+				.andExpect(status().isInternalServerError());
+
+		mockServer.verify();
+	}
+
 	// FaceAPIとの通信でHTTPステータス503が返却される場合
-	// レスポンス　HTTPステータス503を期待
+	// レスポンス HTTPステータス503を期待
 	@Test
 	void testAnalyzeReturn503() throws Exception {
 

--- a/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
+++ b/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
@@ -13,7 +13,6 @@ import com.face.model.ErrorResponse;
 import com.face.model.FaceApiErrorResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -23,46 +22,39 @@ class ResponseFactoryTest {
 	@Autowired
 	ResponseFactory target;
 
-	
+	// レスポンス {"error":"test error"} を期待
 	@Test
 	void testCreateErrorResponse() {
 		
-		String expectedErrorMessage = "test error";
+		String expectedErrorMessage = "test error"; // このAPIから返されるエラー文
 		
 		Exception ex = new NotDetectedException(expectedErrorMessage);
 		// 実行
 		ErrorResponse response = ResponseFactory.createErrorResponse(ex);
-		
-		ErrorResponse expected = new ErrorResponse(expectedErrorMessage);
 		// 比較
-		assertThat(response.getError()).isEqualTo(expected.getError());
+		assertThat(response.getError()).isEqualTo(expectedErrorMessage);
 	}
 
 
+
+	// レスポンス {"error":"Face API response is error.",
+	//          "detail":{"code":"BadArgument",
+	//                    "message":"Request body is invalid."}} を期待
 	@Test
 	void testCreateFaceApiErrorResponse() throws JsonMappingException, JsonProcessingException {
 		
-		String expectedErrorMessage = "test error";
-		String expetedDetailCode = "BadArgument";
-		String expectedDetailMessage = "Request body is invalid.";
+		String expectedErrorMessage = "Face API response is error."; // このAPIから返されるエラー文
+		String expetedDetailCode = "BadArgument"; // FaceAPIからのレスポンス
+		String expectedDetailMessage = "Request body is invalid."; // FaceAPIからのレスポンス
 		
-		Exception ex = new FaceApiInvalidRequestException(expectedErrorMessage);
-		
-		ObjectMapper mapper = new ObjectMapper();
-		FaceApiErrorResponse err = mapper.readValue(ex.getMessage(), FaceApiErrorResponse.class);
-		err.setMessage("{ \"error\": { \"code\": \"" + expetedDetailCode + "\", \"message\": \"" + expectedDetailMessage + "\"} }");
+		String FaceApiErrMessage = "{\"error\":{\"code\":\"" + expetedDetailCode + "\",\"message\":\"" + expectedDetailMessage + "\"}}"; // FaceAPIから返却されるエラーの想定
+		Exception ex = new FaceApiException(FaceApiErrMessage);
 		// 実行
 		FaceApiErrorResponse response = ResponseFactory.createFaceApiErrorResponse(ex);
-		
-		FaceApiErrorResponse expected = new FaceApiErrorResponse();
-		expected.setMessage(expectedErrorMessage);
-		FaceApiErrorResponseDetail aaa = new FaceApiErrorResponseDetail();
-		aaa.setCode(expetedDetailCode);
-		aaa.setMessage(expectedDetailMessage);
-		expected.setDetails(aaa);
 		// 比較
-		assertThat(response.getMessage()).isEqualTo(expected.getMessage());
-		assertThat(response.getDetails()).isEqualTo(expected.getDetails());
+		assertThat(response.getMessage()).isEqualTo(expectedErrorMessage);
+		assertThat(response.getDetails().getCode()).isEqualTo(expetedDetailCode);
+		assertThat(response.getDetails().getMessage()).isEqualTo(expectedDetailMessage);
 	}
 
 }

--- a/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
+++ b/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
@@ -22,7 +22,7 @@ class ResponseFactoryTest {
 	@Autowired
 	ResponseFactory target;
 
-	// レスポンス {"error":"test error"} を期待
+	// ErrorResponseが生成され、そのerrorの値が"test error"であることを期待
 	@Test
 	void testCreateErrorResponse() {
 		
@@ -35,11 +35,9 @@ class ResponseFactoryTest {
 		assertThat(response.getError()).isEqualTo(expectedErrorMessage);
 	}
 
-
-
-	// レスポンス {"error":"Face API response is error.",
-	//          "detail":{"code":"BadArgument",
-	//                    "message":"Request body is invalid."}} を期待
+	// FaceApiErrorResponseが生成され、errorに固定のエラー文、detailsにJSON文字列で指定された(実際には、FaceAPIから返却された)エラーの内容が設定されていることを期待。
+	// FaceApiErrorResponse.errorは固定のエラー文"Face API response is error."
+	// FaceApiErrorResponse.detailのcode, messageにSON文字列で指定されたエラーの内容が格納
 	@Test
 	void testCreateFaceApiErrorResponse() throws JsonMappingException, JsonProcessingException {
 		

--- a/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
+++ b/server/FaceEmotionAnalyzerAPI/src/test/java/com/face/response/ResponseFactoryTest.java
@@ -1,0 +1,68 @@
+package com.face.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.face.model.ErrorResponse;
+import com.face.model.FaceApiErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class ResponseFactoryTest {
+
+	@Autowired
+	ResponseFactory target;
+
+	
+	@Test
+	void testCreateErrorResponse() {
+		
+		String expectedErrorMessage = "test error";
+		
+		Exception ex = new NotDetectedException(expectedErrorMessage);
+		// é¿çs
+		ErrorResponse response = ResponseFactory.createErrorResponse(ex);
+		
+		ErrorResponse expected = new ErrorResponse(expectedErrorMessage);
+		// î‰är
+		assertThat(response.getError()).isEqualTo(expected.getError());
+	}
+
+
+	@Test
+	void testCreateFaceApiErrorResponse() throws JsonMappingException, JsonProcessingException {
+		
+		String expectedErrorMessage = "test error";
+		String expetedDetailCode = "BadArgument";
+		String expectedDetailMessage = "Request body is invalid.";
+		
+		Exception ex = new FaceApiInvalidRequestException(expectedErrorMessage);
+		
+		ObjectMapper mapper = new ObjectMapper();
+		FaceApiErrorResponse err = mapper.readValue(ex.getMessage(), FaceApiErrorResponse.class);
+		err.setMessage("{ \"error\": { \"code\": \"" + expetedDetailCode + "\", \"message\": \"" + expectedDetailMessage + "\"} }");
+		// é¿çs
+		FaceApiErrorResponse response = ResponseFactory.createFaceApiErrorResponse(ex);
+		
+		FaceApiErrorResponse expected = new FaceApiErrorResponse();
+		expected.setMessage(expectedErrorMessage);
+		FaceApiErrorResponseDetail aaa = new FaceApiErrorResponseDetail();
+		aaa.setCode(expetedDetailCode);
+		aaa.setMessage(expectedDetailMessage);
+		expected.setDetails(aaa);
+		// î‰är
+		assertThat(response.getMessage()).isEqualTo(expected.getMessage());
+		assertThat(response.getDetails()).isEqualTo(expected.getDetails());
+	}
+
+}


### PR DESCRIPTION
1/29修正点
- テストコメントの修正

1/28日修正点
- インデントの修正
- FaceAPIからのエラーが400、429以外の場合を追加
- 2人以上の分析結果の場合を追加
- FaceAPIとの通信をすべてモックを使用するように変更
- @BeforによるMockMvcの初期化処理の削除(@AutoConfigureMockMvcが自動で行ってくれるため必要ない)

-----

**【OJT後半課題①】単体テスト　作成**

OJT課題で作成しているWebAPIの単体テストを作成しました。
単体テストを行っているクラスは

- FaceEmotionController.java
- ResponseFactory.java

の2つのクラスになります。
setter/getter以外のメソッドを持っていないクラスは単体テストを行っていません。
単体テストソースファイルは以下の2つになります。
- FaceEmotionControllerTest.java
- ResponseFactoryTest.java

この2つの単体テストに関して、
単体テストコードの書き方
テストパターンの不足はないか
などの確認をお願いします。

**カバレッジ**
カバレッジに関しては以下のzipファイルから確認ください。
[coverage.zip](https://github.com/nishikawa1114/FaceEmotionSystem/files/5884599/coverage.zip)
解凍されたファイルのindex.htmlから、以下の順番で選択すれば外套のファイルのカバレジを見ることができます。FaceEmotionAnalyzerAPI→src/main/java→com.face.controller→FaceEmotionController→FaceEmotionController()をクリック
FaceEmotionAnalyzerAPI→src/main/java→com.face.response→ResponseFactory→ResponseFactory()をクリック

**参考**
- API仕様書
http://htmlpreview.github.io/?https://github.com/nishikawa1114/FaceEmotionSystem/blob/api_specification/doc/api/api.html